### PR TITLE
Convert for python 3

### DIFF
--- a/data.py
+++ b/data.py
@@ -50,4 +50,4 @@ import pandas.io.data as web
 all_data = {}
 for ticker in ['AAPL', 'IBM', 'YHOO', 'MSFT']:
     all_data[ticker] = web.get_data_yahoo(ticker, '1/1/2012', '1/1/2014')
-price = pd.DataFrame({tic: data['Adj Close'] for tic, data in all_data.iteritems()})
+price = pd.DataFrame({tic: data['Adj Close'] for tic, data in iter(all_data.items())})


### PR DESCRIPTION
Resolves `'dict' object has no attribute 'iteritems'` under Python 3
http://legacy.python.org/dev/peps/pep-0469/

You may wish to make a new branch for python 2 and keep master for python 3 upstream-latest compatible source.

Thanks for this project. :+1: 
